### PR TITLE
12 refactor xgbquantileforecaster

### DIFF
--- a/dvc.lock
+++ b/dvc.lock
@@ -71,9 +71,9 @@ stages:
       size: 1432579
     - path: src/probafcst//models/
       hash: md5
-      md5: 5143129e175f75fb09075823d376cd67.dir
-      size: 26388
-      nfiles: 8
+      md5: cd4a69bcb786159fd9d45d03f947c93b.dir
+      size: 35125
+      nfiles: 12
     - path: src/probafcst/pipeline/train.py
       hash: md5
       md5: f76a84ee80300ed55740666fe147ec40
@@ -127,8 +127,8 @@ stages:
     outs:
     - path: models/energy_model.pkl
       hash: md5
-      md5: 0bea63f9dab98fb1c496e152a4e58819
-      size: 2728146
+      md5: 8d8436a4100118ce03b4fe524f636b3e
+      size: 2728173
   train@bikes:
     cmd: python src/probafcst/pipeline/train.py --target bikes
     deps:
@@ -138,9 +138,9 @@ stages:
       size: 161808
     - path: src/probafcst//models/
       hash: md5
-      md5: 5143129e175f75fb09075823d376cd67.dir
-      size: 26388
-      nfiles: 8
+      md5: cd4a69bcb786159fd9d45d03f947c93b.dir
+      size: 35125
+      nfiles: 12
     - path: src/probafcst/pipeline/train.py
       hash: md5
       md5: f76a84ee80300ed55740666fe147ec40
@@ -196,8 +196,8 @@ stages:
     outs:
     - path: models/bikes_model.pkl
       hash: md5
-      md5: f118656fc9174ec4e35db951e2005f87
-      size: 1209916
+      md5: 516a56b98ea7e312a6041d35b150dd4f
+      size: 1209937
   eval@energy:
     cmd: python src/probafcst/pipeline/evaluate.py --target energy
     deps:
@@ -207,8 +207,8 @@ stages:
       size: 1432579
     - path: models/energy_model.pkl
       hash: md5
-      md5: 0bea63f9dab98fb1c496e152a4e58819
-      size: 2728146
+      md5: 8d8436a4100118ce03b4fe524f636b3e
+      size: 2728173
     - path: src/probafcst//backtest.py
       hash: md5
       md5: 505516c71fd56edfacdb8843e430d129
@@ -237,19 +237,19 @@ stages:
     outs:
     - path: output/energy_eval_results.csv
       hash: md5
-      md5: 0e36a3536a01b737baa449ae27add310
-      size: 5226
+      md5: b7b094995dcf8a9adee77909a6b57301
+      size: 5228
     - path: output/energy_metrics.json
       hash: md5
-      md5: cb4795549ba5d53e61c3929f58c5cce0
+      md5: 8705a900c1b4fd6abaade4715d13fea9
       size: 179
     - path: output/energy_pinball_losses.svg
       hash: md5
-      md5: ea424220897d2a50fdec8e6bc1cff7ba
+      md5: 3e7245d66a1b9387651944727d30da6e
       size: 25648
     - path: output/eval_plots/energy/
       hash: md5
-      md5: c94cef51cce913e7338a0412fce673c1.dir
+      md5: 954edaf8fb012537cc6a96e91103a3c8.dir
       size: 213925
       nfiles: 3
   eval@bikes:
@@ -261,8 +261,8 @@ stages:
       size: 161808
     - path: models/bikes_model.pkl
       hash: md5
-      md5: f118656fc9174ec4e35db951e2005f87
-      size: 1209916
+      md5: 516a56b98ea7e312a6041d35b150dd4f
+      size: 1209937
     - path: src/probafcst//backtest.py
       hash: md5
       md5: 505516c71fd56edfacdb8843e430d129
@@ -291,19 +291,19 @@ stages:
     outs:
     - path: output/bikes_eval_results.csv
       hash: md5
-      md5: ba89cac78834a7d1f17cb8f21fb44ba7
-      size: 19551
+      md5: ec67053815f88bb77eecbe605854a4e6
+      size: 19540
     - path: output/bikes_metrics.json
       hash: md5
-      md5: c09f7616adabaa0cbfb82e00eb1fda8f
+      md5: 3af952545a702ab47b317cf54dfe87cc
       size: 179
     - path: output/bikes_pinball_losses.svg
       hash: md5
-      md5: d618d9123fb63eda5a4fc37e0c9f2bf4
+      md5: d9f6bc430596b1bc5f91349dfd51812d
       size: 30128
     - path: output/eval_plots/bikes/
       hash: md5
-      md5: d1a4a59189ce73e9353c1a21c981e81e.dir
+      md5: cebaa37445737a285a204a5387ad865e.dir
       size: 98128
       nfiles: 3
   submit:
@@ -311,12 +311,12 @@ stages:
     deps:
     - path: models/bikes_model.pkl
       hash: md5
-      md5: f118656fc9174ec4e35db951e2005f87
-      size: 1209916
+      md5: 516a56b98ea7e312a6041d35b150dd4f
+      size: 1209937
     - path: models/energy_model.pkl
       hash: md5
-      md5: 0bea63f9dab98fb1c496e152a4e58819
-      size: 2728146
+      md5: 8d8436a4100118ce03b4fe524f636b3e
+      size: 2728173
     - path: src/probafcst//plotting.py
       hash: md5
       md5: 482a42cf8b0b9196d98b0d8e772d83d2
@@ -344,13 +344,13 @@ stages:
     outs:
     - path: output/bikes_forecast.svg
       hash: md5
-      md5: 38217390dfe295c446cc5cc31c23008c
+      md5: caac5c419e40d95be363525155816fb8
       size: 31625
     - path: output/energy_forecast.svg
       hash: md5
-      md5: ce6860c69d491b3e242a52b171e24920
+      md5: d3b9ebbd7bd6873659e750296c7ea499
       size: 70211
     - path: output/submission.csv
       hash: md5
-      md5: 0a5f0570fd3e46c2240295b1246548c8
+      md5: 942132d2c0e216906c3b535fadbefcfc
       size: 1553

--- a/dvc.lock
+++ b/dvc.lock
@@ -71,8 +71,8 @@ stages:
       size: 1434243
     - path: src/probafcst//models/
       hash: md5
-      md5: cd14fb21c4493537163d052787f428a0.dir
-      size: 53306
+      md5: 4ec25f71ecf351411d21a8d4845301f8.dir
+      size: 53648
       nfiles: 15
     - path: src/probafcst/pipeline/train.py
       hash: md5
@@ -135,17 +135,24 @@ stages:
             lags:
             - 24
             - 48
+            - 72
+            - 96
+            - 120
+            - 144
             - 168
+            - 336
+            - 504
+            - 672
             include_seasonal_dummies: true
-            cyclical_encodings: true
+            cyclical_encodings: false
             X_lag_cols:
             kwargs:
               n_jobs: -1
     outs:
     - path: models/energy_model.pkl
       hash: md5
-      md5: 29fa3a67fb852680ae2a0defc0907572
-      size: 2683061
+      md5: 10d49b272dd2c24b453359b6ce0bc4ae
+      size: 2683591
   train@bikes:
     cmd: python src/probafcst/pipeline/train.py --target bikes
     deps:
@@ -155,8 +162,8 @@ stages:
       size: 161429
     - path: src/probafcst//models/
       hash: md5
-      md5: cd14fb21c4493537163d052787f428a0.dir
-      size: 53306
+      md5: 4ec25f71ecf351411d21a8d4845301f8.dir
+      size: 53648
       nfiles: 15
     - path: src/probafcst/pipeline/train.py
       hash: md5
@@ -233,11 +240,12 @@ stages:
             X_lag_cols:
             kwargs:
               n_jobs: -1
+              verbose: -1
     outs:
     - path: models/bikes_model.pkl
       hash: md5
-      md5: 6e106d09392529186d9882697130978f
-      size: 1207166
+      md5: ef96fbd3b0deb1d63cbfd16b2cce1c13
+      size: 1207698
   eval@energy:
     cmd: python src/probafcst/pipeline/evaluate.py --target energy
     deps:
@@ -247,8 +255,8 @@ stages:
       size: 1434243
     - path: models/energy_model.pkl
       hash: md5
-      md5: 29fa3a67fb852680ae2a0defc0907572
-      size: 2683061
+      md5: 10d49b272dd2c24b453359b6ce0bc4ae
+      size: 2683591
     - path: src/probafcst//backtest.py
       hash: md5
       md5: 505516c71fd56edfacdb8843e430d129
@@ -277,19 +285,19 @@ stages:
     outs:
     - path: output/energy_eval_results.csv
       hash: md5
-      md5: afae4a655ca8ca80f69d0600045762db
-      size: 5229
+      md5: 639a476f4259d4ce5c9acaf3d3b59750
+      size: 5228
     - path: output/energy_metrics.json
       hash: md5
-      md5: 42755e4a480460c360c28bd3ec7b560b
+      md5: 39f931be88878ac9ff907200b6a588e6
       size: 180
     - path: output/energy_pinball_losses.svg
       hash: md5
-      md5: 97249b6e910fe208a998ad222b420dd7
+      md5: e3587b70a4c9f2ffe778442688ff57cd
       size: 25435
     - path: output/eval_plots/energy/
       hash: md5
-      md5: 5b7e9f33f706717db38dd9ebf4bd2fb6.dir
+      md5: 01ba8faee3dfe803c544703c6f8b5323.dir
       size: 213962
       nfiles: 3
   eval@bikes:
@@ -301,8 +309,8 @@ stages:
       size: 161429
     - path: models/bikes_model.pkl
       hash: md5
-      md5: 6e106d09392529186d9882697130978f
-      size: 1207166
+      md5: ef96fbd3b0deb1d63cbfd16b2cce1c13
+      size: 1207698
     - path: src/probafcst//backtest.py
       hash: md5
       md5: 505516c71fd56edfacdb8843e430d129
@@ -331,19 +339,19 @@ stages:
     outs:
     - path: output/bikes_eval_results.csv
       hash: md5
-      md5: a13a680a578f10b3b0b273cc1ef2af32
-      size: 19527
+      md5: f17230ec60796b84bdc4449590f65199
+      size: 19534
     - path: output/bikes_metrics.json
       hash: md5
-      md5: 29daa8a8d7ea66c0735fafe6c276fa3a
-      size: 180
+      md5: d219135395c32b555b79c042d354df5c
+      size: 179
     - path: output/bikes_pinball_losses.svg
       hash: md5
-      md5: 7e0983e5014146c325076912a1aa9be1
+      md5: 968734e747ac97e547d95a4e954b944c
       size: 28874
     - path: output/eval_plots/bikes/
       hash: md5
-      md5: c4b8a0de17d166fc5e71993c15f9d91e.dir
+      md5: 76ab82753034364fbf9f5d0b9a9430a5.dir
       size: 95861
       nfiles: 3
   submit:
@@ -351,12 +359,12 @@ stages:
     deps:
     - path: models/bikes_model.pkl
       hash: md5
-      md5: 6e106d09392529186d9882697130978f
-      size: 1207166
+      md5: ef96fbd3b0deb1d63cbfd16b2cce1c13
+      size: 1207698
     - path: models/energy_model.pkl
       hash: md5
-      md5: 29fa3a67fb852680ae2a0defc0907572
-      size: 2683061
+      md5: 10d49b272dd2c24b453359b6ce0bc4ae
+      size: 2683591
     - path: src/probafcst//plotting.py
       hash: md5
       md5: 482a42cf8b0b9196d98b0d8e772d83d2
@@ -384,11 +392,11 @@ stages:
     outs:
     - path: output/bikes_forecast.svg
       hash: md5
-      md5: 4cc948c95234233d55a211c0308cdf3c
+      md5: fdbebee27a69f92c9f788a9756162f8b
       size: 32263
     - path: output/energy_forecast.svg
       hash: md5
-      md5: 3c00e21317564f7142ed0dd0af1d0e28
+      md5: a520e833553dc0f214e8aa0cac6e4136
       size: 65716
     - path: output/submission.csv
       hash: md5

--- a/dvc.lock
+++ b/dvc.lock
@@ -27,8 +27,8 @@ stages:
     outs:
     - path: data/energy.parquet
       hash: md5
-      md5: 6703ac0097a5c2ff91c10633704da0f8
-      size: 1432579
+      md5: fd9384b1014dc5bd99a169c3934812c5
+      size: 1434243
   prepare@bikes:
     cmd: python src/probafcst/pipeline/prepare.py --target bikes
     deps:
@@ -60,20 +60,20 @@ stages:
     outs:
     - path: data/bikes.parquet
       hash: md5
-      md5: 5673f4a0888ae622f40270342ea1cd73
-      size: 161808
+      md5: 89167d59e8f41e79709adc267ef28190
+      size: 161429
   train@energy:
     cmd: python src/probafcst/pipeline/train.py --target energy
     deps:
     - path: data/energy.parquet
       hash: md5
-      md5: 6703ac0097a5c2ff91c10633704da0f8
-      size: 1432579
+      md5: fd9384b1014dc5bd99a169c3934812c5
+      size: 1434243
     - path: src/probafcst//models/
       hash: md5
-      md5: cd4a69bcb786159fd9d45d03f947c93b.dir
-      size: 35125
-      nfiles: 12
+      md5: cd14fb21c4493537163d052787f428a0.dir
+      size: 53306
+      nfiles: 15
     - path: src/probafcst/pipeline/train.py
       hash: md5
       md5: f76a84ee80300ed55740666fe147ec40
@@ -100,8 +100,15 @@ stages:
           benchmark:
             n_weeks: 100
           quantreg:
-            freq: h
-            output_chunk_length: 24
+            kwargs:
+              solver: highs-ipm
+            lags:
+            - 24
+            - 48
+            - 168
+            include_seasonal_dummies: true
+            cyclical_encodings: true
+            X_lag_cols:
           xgboost:
             freq: h
             output_chunk_length: 24
@@ -122,25 +129,35 @@ stages:
             include_seasonal_dummies: true
             cyclical_encodings: false
             X_lag_cols:
-            xgb_kwargs:
+            kwargs:
+              n_jobs: -1
+          lgbm:
+            lags:
+            - 24
+            - 48
+            - 168
+            include_seasonal_dummies: true
+            cyclical_encodings: true
+            X_lag_cols:
+            kwargs:
               n_jobs: -1
     outs:
     - path: models/energy_model.pkl
       hash: md5
-      md5: 8d8436a4100118ce03b4fe524f636b3e
-      size: 2728173
+      md5: 29fa3a67fb852680ae2a0defc0907572
+      size: 2683061
   train@bikes:
     cmd: python src/probafcst/pipeline/train.py --target bikes
     deps:
     - path: data/bikes.parquet
       hash: md5
-      md5: 5673f4a0888ae622f40270342ea1cd73
-      size: 161808
+      md5: 89167d59e8f41e79709adc267ef28190
+      size: 161429
     - path: src/probafcst//models/
       hash: md5
-      md5: cd4a69bcb786159fd9d45d03f947c93b.dir
-      size: 35125
-      nfiles: 12
+      md5: cd14fb21c4493537163d052787f428a0.dir
+      size: 53306
+      nfiles: 15
     - path: src/probafcst/pipeline/train.py
       hash: md5
       md5: f76a84ee80300ed55740666fe147ec40
@@ -171,8 +188,16 @@ stages:
           benchmark:
             n_weeks: 100
           quantreg:
-            freq: D
-            output_chunk_length: 7
+            kwargs:
+              solver: highs-ipm
+            lags:
+            - 1
+            - 2
+            - 7
+            - 14
+            include_seasonal_dummies: true
+            cyclical_encodings: true
+            X_lag_cols:
           xgboost:
             freq: D
             output_chunk_length: 7
@@ -191,24 +216,39 @@ stages:
             include_seasonal_dummies: true
             cyclical_encodings: false
             X_lag_cols:
-            xgb_kwargs:
+            kwargs:
+              n_jobs: -1
+          lgbm:
+            lags:
+            - 1
+            - 2
+            - 3
+            - 4
+            - 5
+            - 6
+            - 7
+            - 14
+            include_seasonal_dummies: true
+            cyclical_encodings: false
+            X_lag_cols:
+            kwargs:
               n_jobs: -1
     outs:
     - path: models/bikes_model.pkl
       hash: md5
-      md5: 516a56b98ea7e312a6041d35b150dd4f
-      size: 1209937
+      md5: 6e106d09392529186d9882697130978f
+      size: 1207166
   eval@energy:
     cmd: python src/probafcst/pipeline/evaluate.py --target energy
     deps:
     - path: data/energy.parquet
       hash: md5
-      md5: 6703ac0097a5c2ff91c10633704da0f8
-      size: 1432579
+      md5: fd9384b1014dc5bd99a169c3934812c5
+      size: 1434243
     - path: models/energy_model.pkl
       hash: md5
-      md5: 8d8436a4100118ce03b4fe524f636b3e
-      size: 2728173
+      md5: 29fa3a67fb852680ae2a0defc0907572
+      size: 2683061
     - path: src/probafcst//backtest.py
       hash: md5
       md5: 505516c71fd56edfacdb8843e430d129
@@ -237,32 +277,32 @@ stages:
     outs:
     - path: output/energy_eval_results.csv
       hash: md5
-      md5: b7b094995dcf8a9adee77909a6b57301
-      size: 5228
+      md5: afae4a655ca8ca80f69d0600045762db
+      size: 5229
     - path: output/energy_metrics.json
       hash: md5
-      md5: 8705a900c1b4fd6abaade4715d13fea9
-      size: 179
+      md5: 42755e4a480460c360c28bd3ec7b560b
+      size: 180
     - path: output/energy_pinball_losses.svg
       hash: md5
-      md5: 3e7245d66a1b9387651944727d30da6e
-      size: 25648
+      md5: 97249b6e910fe208a998ad222b420dd7
+      size: 25435
     - path: output/eval_plots/energy/
       hash: md5
-      md5: 954edaf8fb012537cc6a96e91103a3c8.dir
-      size: 213925
+      md5: 5b7e9f33f706717db38dd9ebf4bd2fb6.dir
+      size: 213962
       nfiles: 3
   eval@bikes:
     cmd: python src/probafcst/pipeline/evaluate.py --target bikes
     deps:
     - path: data/bikes.parquet
       hash: md5
-      md5: 5673f4a0888ae622f40270342ea1cd73
-      size: 161808
+      md5: 89167d59e8f41e79709adc267ef28190
+      size: 161429
     - path: models/bikes_model.pkl
       hash: md5
-      md5: 516a56b98ea7e312a6041d35b150dd4f
-      size: 1209937
+      md5: 6e106d09392529186d9882697130978f
+      size: 1207166
     - path: src/probafcst//backtest.py
       hash: md5
       md5: 505516c71fd56edfacdb8843e430d129
@@ -291,32 +331,32 @@ stages:
     outs:
     - path: output/bikes_eval_results.csv
       hash: md5
-      md5: ec67053815f88bb77eecbe605854a4e6
-      size: 19540
+      md5: a13a680a578f10b3b0b273cc1ef2af32
+      size: 19527
     - path: output/bikes_metrics.json
       hash: md5
-      md5: 3af952545a702ab47b317cf54dfe87cc
-      size: 179
+      md5: 29daa8a8d7ea66c0735fafe6c276fa3a
+      size: 180
     - path: output/bikes_pinball_losses.svg
       hash: md5
-      md5: d9f6bc430596b1bc5f91349dfd51812d
-      size: 30128
+      md5: 7e0983e5014146c325076912a1aa9be1
+      size: 28874
     - path: output/eval_plots/bikes/
       hash: md5
-      md5: cebaa37445737a285a204a5387ad865e.dir
-      size: 98128
+      md5: c4b8a0de17d166fc5e71993c15f9d91e.dir
+      size: 95861
       nfiles: 3
   submit:
     cmd: python src/probafcst/pipeline/submit.py
     deps:
     - path: models/bikes_model.pkl
       hash: md5
-      md5: 516a56b98ea7e312a6041d35b150dd4f
-      size: 1209937
+      md5: 6e106d09392529186d9882697130978f
+      size: 1207166
     - path: models/energy_model.pkl
       hash: md5
-      md5: 8d8436a4100118ce03b4fe524f636b3e
-      size: 2728173
+      md5: 29fa3a67fb852680ae2a0defc0907572
+      size: 2683061
     - path: src/probafcst//plotting.py
       hash: md5
       md5: 482a42cf8b0b9196d98b0d8e772d83d2
@@ -344,13 +384,13 @@ stages:
     outs:
     - path: output/bikes_forecast.svg
       hash: md5
-      md5: caac5c419e40d95be363525155816fb8
-      size: 31625
+      md5: 4cc948c95234233d55a211c0308cdf3c
+      size: 32263
     - path: output/energy_forecast.svg
       hash: md5
-      md5: d3b9ebbd7bd6873659e750296c7ea499
-      size: 70211
+      md5: 3c00e21317564f7142ed0dd0af1d0e28
+      size: 65716
     - path: output/submission.csv
       hash: md5
-      md5: 942132d2c0e216906c3b535fadbefcfc
-      size: 1553
+      md5: 77e8acfa7c4ce2c0f7107f3657860c45
+      size: 1563

--- a/notebooks/xgboost.ipynb
+++ b/notebooks/xgboost.ipynb
@@ -54,6 +54,7 @@
     "lags = [1, 2, 3, 4, 5, 6, 7, 14, 21, 28]\n",
     "\n",
     "\n",
+    "fh = ForecastingHorizon(y_test.index, is_relative=False)\n",
     "xgb_kwargs = dict(\n",
     "    n_jobs=-1,\n",
     "    # early_stopping_rounds=50,\n",
@@ -71,6 +72,22 @@
     ")\n",
     "model.fit(y_train, X_train)\n",
     "model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from probafcst.models.lgbm import LGBMQuantileForecaster\n",
+    "\n",
+    "model = LGBMQuantileForecaster(\n",
+    "    lags=[1, 2], quantiles=quantiles, lgbm_kwargs=dict(verbose=0, n_estimators=10)\n",
+    ")\n",
+    "\n",
+    "model.fit(y_train, X_train)\n",
+    "y_pred = model.predict_quantiles(fh, X, alpha=quantiles)"
    ]
   },
   {

--- a/params.yaml
+++ b/params.yaml
@@ -51,9 +51,19 @@ train:
     cutoff: '2021-11-14' # use only data onwards this date for training the final model
     benchmark:
       n_weeks: 100
+
     quantreg:
-      freq: D
-      output_chunk_length: 7
+      kwargs:
+        solver: highs-ipm
+      lags:
+        - 1
+        - 2
+        - 7
+        - 14
+      include_seasonal_dummies: true
+      cyclical_encodings: true
+      X_lag_cols: null
+
     xgboost:
       freq: D
       output_chunk_length: 7
@@ -72,13 +82,28 @@ train:
       include_seasonal_dummies: true
       cyclical_encodings: false
       X_lag_cols: null
-      xgb_kwargs:
+      kwargs:
         n_jobs: -1
         # early_stopping_rounds: 50
         # n_estimators: 1000
         # learning_rate: 0.05
         # subsample: 0.8
         # colsample_bytree: 0.8
+    lgbm:
+      lags:
+        - 1
+        - 2
+        - 3
+        - 4
+        - 5
+        - 6
+        - 7
+        - 14
+      include_seasonal_dummies: true
+      cyclical_encodings: false
+      X_lag_cols: null
+      kwargs:
+        n_jobs: -1
 
 
   energy:
@@ -86,14 +111,24 @@ train:
     cutoff: '2021-11-14'
     benchmark:
       n_weeks: 100
+
     quantreg:
-      freq: h
-      output_chunk_length: 24
+      kwargs:
+        solver: highs-ipm
+      lags:
+        - 24
+        - 48
+        - 168
+      include_seasonal_dummies: true
+      cyclical_encodings: true
+      X_lag_cols: null
+
     xgboost:
       freq: h
       output_chunk_length: 24
       xgb_kwargs:
         n_jobs: -1
+
     xgb-custom:
       lags:
         - 24
@@ -109,13 +144,23 @@ train:
       include_seasonal_dummies: true
       cyclical_encodings: false
       X_lag_cols: null
-      xgb_kwargs:
+      kwargs:
         n_jobs: -1
         # early_stopping_rounds: 50
         # n_estimators: 1000
         # learning_rate: 0.05
         # subsample: 0.8
         # colsample_bytree: 0.8
+    lgbm:
+      lags:
+        - 24
+        - 48
+        - 168
+      include_seasonal_dummies: true
+      cyclical_encodings: true
+      X_lag_cols: null
+      kwargs:
+        n_jobs: -1
 
 eval:
   backend: loky # null or 'loky' for parallel evaluate

--- a/params.yaml
+++ b/params.yaml
@@ -104,6 +104,7 @@ train:
       X_lag_cols: null
       kwargs:
         n_jobs: -1
+        verbose: -1
 
 
   energy:
@@ -155,9 +156,16 @@ train:
       lags:
         - 24
         - 48
+        - 72
+        - 96
+        - 120
+        - 144
         - 168
+        - 336 # 2 weeks
+        - 504 # 3 weeks
+        - 672
       include_seasonal_dummies: true
-      cyclical_encodings: true
+      cyclical_encodings: false
       X_lag_cols: null
       kwargs:
         n_jobs: -1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "shap>=0.46.0",
     "openmeteo-requests>=1.3.0",
     "retry-requests>=2.0.0",
+    "lightgbm>=4.5.0",
 ]
 
 

--- a/src/probafcst/models/__init__.py
+++ b/src/probafcst/models/__init__.py
@@ -1,6 +1,18 @@
-"""Models for probabilistic forecasting."""
+"""Models for probabilistic forecasting.
 
-from . import darts
+This module contains implementations for probabilistic forecasting models. This project
+focuses on quantile predictions, therefore the models are designed to predict multiple quantile levels.
+"""
+
+from . import darts, lgbm, linear_qr, regression, xgboost
 from ._base import BenchmarkForecaster, get_model
 
-__all__ = ["BenchmarkForecaster", "get_model", "darts"]
+__all__ = [
+    "BenchmarkForecaster",
+    "get_model",
+    "darts",
+    "regression",
+    "xgboost",
+    "linear_qr",
+    "lgbm",
+]

--- a/src/probafcst/models/_base.py
+++ b/src/probafcst/models/_base.py
@@ -7,7 +7,9 @@ import pandas as pd
 from omegaconf import DictConfig
 from sktime.forecasting.base import BaseForecaster
 
-from probafcst.models.darts import get_quantile_regressor, get_xgboost_model
+from probafcst.models.darts import get_xgboost_model
+from probafcst.models.lgbm import LGBMQuantileForecaster
+from probafcst.models.linear_qr import LinearQuantileForecaster
 from probafcst.models.xgboost import XGBQuantileForecaster
 
 
@@ -30,7 +32,9 @@ def get_model(
         case "benchmark":
             model = BenchmarkForecaster(**model_params)
         case "quantreg":
-            model = get_quantile_regressor(**model_params, quantiles=quantiles)
+            if n_jobs is not None:
+                model_params["kwargs"]["n_jobs"] = n_jobs
+            model = LinearQuantileForecaster(**model_params, quantiles=quantiles)
         case "xgboost":
             model = get_xgboost_model(**model_params, quantiles=quantiles)
             if n_jobs is not None:
@@ -40,8 +44,12 @@ def get_model(
                 model.set_params(kwargs=kwargs)
         case "xgb-custom":
             if n_jobs is not None:
-                model_params["xgb_kwargs"]["n_jobs"] = n_jobs
+                model_params["kwargs"]["n_jobs"] = n_jobs
             model = XGBQuantileForecaster(**model_params, quantiles=quantiles)
+        case "lgbm":
+            if n_jobs is not None:
+                model_params["kwargs"]["n_jobs"] = n_jobs
+            model = LGBMQuantileForecaster(**model_params, quantiles=quantiles)
 
     return model
 

--- a/src/probafcst/models/_base.py
+++ b/src/probafcst/models/_base.py
@@ -32,8 +32,6 @@ def get_model(
         case "benchmark":
             model = BenchmarkForecaster(**model_params)
         case "quantreg":
-            if n_jobs is not None:
-                model_params["kwargs"]["n_jobs"] = n_jobs
             model = LinearQuantileForecaster(**model_params, quantiles=quantiles)
         case "xgboost":
             model = get_xgboost_model(**model_params, quantiles=quantiles)

--- a/src/probafcst/models/_regression.py
+++ b/src/probafcst/models/_regression.py
@@ -79,7 +79,23 @@ class MultipleQuantileRegressor(BaseEstimator, RegressorMixin):
 
 
 class QuantileRegressionForecaster(BaseForecaster):
-    """Probabilistic regression forecaster for quantile forecasting."""
+    """Probabilistic regression forecaster for quantile forecasting.
+
+    Parameters
+    ----------
+    model : BaseEstimator
+        Model that supports quantile regression.
+    lags : list of int
+        List of lag values to use for creating lagged features.
+    quantiles : list of float
+        List of quantiles to predict.
+    include_seasonal_dummies : bool, default=True
+        If True, include seasonal dummy variables in the lagged features.
+    cyclical_encodings : bool, default=True
+        If True, use cyclical (cos and sin functions) encoding for time features.
+    X_lag_cols : list of str, default=None
+        List of column names in X to include as lagged features. If None, all columns are used.
+    """
 
     _tags = {
         "y_inner_mtype": "pd.Series",

--- a/src/probafcst/models/_regression.py
+++ b/src/probafcst/models/_regression.py
@@ -1,0 +1,138 @@
+"""Probabilistic XGBoost Forecasting Model."""
+
+import numpy as np
+import pandas as pd
+from loguru import logger
+from sklearn.base import BaseEstimator
+from sktime.forecasting.base import BaseForecaster
+
+from probafcst.utils.tabularization import create_lagged_features
+
+
+class QuantileRegressionForecaster(BaseForecaster):
+    """Probabilistic regression forecaster for quantile forecasting."""
+
+    _tags = {
+        "y_inner_mtype": "pd.Series",
+        "X_inner_mtype": "pd.DataFrame",
+        "scitype:y": "univariate",
+        "ignores-exogeneous-X": False,
+        "requires-fh-in-fit": False,
+        "enforce_index_type": pd.DatetimeIndex,
+        "X-y-must-have-same-index": True,
+        "handles-missing-data": False,
+        "capability:insample": False,
+        "capability:pred_int": True,
+    }
+
+    def __init__(
+        self,
+        model: BaseEstimator,
+        lags: list[int],
+        quantiles: list[int],
+        include_seasonal_dummies=True,
+        cyclical_encodings=True,
+        X_lag_cols: list[str] | None = None,
+    ):
+        self.lags = lags
+        self.quantiles = quantiles
+        self.include_seasonal_dummies = include_seasonal_dummies
+        self.cyclical_encodings = cyclical_encodings
+        self.X_lag_cols = X_lag_cols
+
+        self.model = model
+
+        super().__init__()
+
+    def _fit(self, y, X, fh=None):
+        self.freq_ = pd.infer_freq(y.index)
+        self._target_name = self._y_metadata["feature_names"][0]
+        self.max_lag_ = max(self.lags)
+
+        y = y.copy()
+        y.name = self._target_name
+
+        features, labels = create_lagged_features(
+            X=X,
+            y=y,
+            lags=self.lags,
+            include_seasonal_dummies=self.include_seasonal_dummies,
+            cyclical_encodings=self.cyclical_encodings,
+            X_lag_cols=self.X_lag_cols,
+            is_training=True,
+            freq=self.freq_,
+        )
+
+        self.model.fit(features, labels)
+        self.feature_names_in_ = features.columns
+        return self
+
+    def _predict(self, fh, X=None):
+        # Use _predict_quantiles() to get the median for point prediction
+        quantile_predictions = self._predict_quantiles(fh, X=X, alpha=self.quantiles)
+        return quantile_predictions[(self._target_name, 0.5)]
+
+    def _predict_quantiles(self, fh, X, alpha):
+        if X is None:
+            # index must be the one in _y plus the forecast horizon
+            index = self._y.index.union(fh.to_absolute_index(self.cutoff))
+            X = pd.DataFrame(index=index)
+
+        if X.shape[0] < len(fh):
+            raise ValueError(f"X must contain at least {self.max_lag_} rows")
+        elif X.shape[0] > len(fh):
+            max_needed_timestamp = fh.to_absolute_index(self.cutoff).max()
+            X = X.loc[:max_needed_timestamp]
+            logger.debug(f"X truncated to {X.index[0]} - {X.index[-1]}")
+
+        logger.debug(f"Predicting {len(fh)} steps ahead.")
+        logger.debug(f"Future X shape: {X.shape}")
+
+        assert alpha == self.quantiles, "alpha must be equal to quantiles used in fit"
+
+        y_train = self._y.copy()
+
+        X_full = X.copy()
+        logger.debug(f"X values available from {X_full.index[0]} to {X_full.index[-1]}")
+
+        forecast_index = fh.to_absolute_index(self.cutoff)
+        y_pred = pd.Series(np.nan, index=forecast_index)
+        y_full = pd.concat([y_train, y_pred])
+        y_full.name = self._target_name
+
+        logger.debug(f"Forecast index: {forecast_index[0]} - {forecast_index[-1]}")
+
+        # Initialize results DataFrame
+        results = pd.DataFrame(index=forecast_index, columns=[q for q in alpha])
+
+        for timestamp in forecast_index:
+            X_lagged, _ = create_lagged_features(
+                X=X_full,
+                y=y_full,
+                lags=self.lags,
+                include_seasonal_dummies=self.include_seasonal_dummies,
+                cyclical_encodings=self.cyclical_encodings,
+                X_lag_cols=self.X_lag_cols,
+                is_training=False,
+                freq=self.freq_,
+            )
+
+            X_step = X_lagged.loc[[timestamp]]
+            pred_quantiles_step = self.model.predict(X_step)
+            results.loc[timestamp] = pred_quantiles_step
+
+            # append the median prediction to use for lag creation in the next step
+            median_pred = results.loc[timestamp, 0.5]
+            y_full.loc[timestamp] = median_pred
+
+        columns = pd.MultiIndex.from_product(
+            [[self._target_name], alpha], names=["variable", "quantiles"]
+        )
+        results.columns = columns
+        results = results.astype(float)
+
+        # sort each row in dataframe y_pred ascending over the columns
+        predictions = results.to_numpy()
+        predictions.sort(axis=1)
+        results.iloc[:, :] = predictions
+        return results

--- a/src/probafcst/models/lgbm.py
+++ b/src/probafcst/models/lgbm.py
@@ -2,7 +2,7 @@
 
 import lightgbm as lgb
 
-from probafcst.models._regression import (
+from probafcst.models.regression import (
     MultipleQuantileRegressor,
     QuantileRegressionForecaster,
 )

--- a/src/probafcst/models/lgbm.py
+++ b/src/probafcst/models/lgbm.py
@@ -22,13 +22,13 @@ class LGBMQuantileForecaster(QuantileRegressionForecaster):
         include_seasonal_dummies=True,
         cyclical_encodings=True,
         X_lag_cols: list[str] | None = None,
-        lgbm_kwargs: dict | None = None,
+        kwargs: dict | None = None,
     ):
-        self.lgbm_kwargs = lgbm_kwargs or {}
+        self.kwargs = kwargs or {}
 
         lgb_model = lgb.LGBMRegressor(
             objective="quantile",
-            **self.lgbm_kwargs,
+            **self.kwargs,
         )
         # lgbm does not support native multiple quantile regression
         model = MultipleQuantileRegressor(

--- a/src/probafcst/models/lgbm.py
+++ b/src/probafcst/models/lgbm.py
@@ -1,0 +1,44 @@
+"""LGBM Quantile Regression Model."""
+
+import lightgbm as lgb
+
+from probafcst.models._regression import (
+    MultipleQuantileRegressor,
+    QuantileRegressionForecaster,
+)
+
+
+class LGBMQuantileForecaster(QuantileRegressionForecaster):
+    """Quantile regression forecaster using LightGBM.
+
+    A forecaster model that uses LightGBM for quantile regression forecasting. This class inherits from
+    QuantileRegressionForecaster and is designed to predict quantiles of the target variable distribution.
+    """
+
+    def __init__(
+        self,
+        lags: list[int],
+        quantiles: list[int],
+        include_seasonal_dummies=True,
+        cyclical_encodings=True,
+        X_lag_cols: list[str] | None = None,
+        lgbm_kwargs: dict | None = None,
+    ):
+        self.lgbm_kwargs = lgbm_kwargs or {}
+
+        lgb_model = lgb.LGBMRegressor(
+            objective="quantile",
+            **self.lgbm_kwargs,
+        )
+        # lgbm does not support native multiple quantile regression
+        model = MultipleQuantileRegressor(
+            quantiles=quantiles, regressor=lgb_model, alpha_name="alpha"
+        )
+        super().__init__(
+            model=model,
+            lags=lags,
+            quantiles=quantiles,
+            include_seasonal_dummies=include_seasonal_dummies,
+            cyclical_encodings=cyclical_encodings,
+            X_lag_cols=X_lag_cols,
+        )

--- a/src/probafcst/models/linear_qr.py
+++ b/src/probafcst/models/linear_qr.py
@@ -1,0 +1,38 @@
+"""Linear Quantile Regression model."""
+
+from sklearn.linear_model import QuantileRegressor
+
+from ._regression import MultipleQuantileRegressor, QuantileRegressionForecaster
+
+
+class LinearQuantileForecaster(QuantileRegressionForecaster):
+    """Linear Quantile Regression model."""
+
+    def __init__(
+        self,
+        lags: list[int],
+        quantiles: list[int],
+        include_seasonal_dummies=True,
+        cyclical_encodings=True,
+        X_lag_cols: list[str] | None = None,
+        est_kwargs: dict | None = None,
+    ):
+        self.est_kwargs = est_kwargs or {}
+
+        # use different default solver
+        if "solver" not in self.est_kwargs:
+            self.est_kwargs["solver"] = "highs-ipm"
+
+        regressor = QuantileRegressor(**self.est_kwargs)
+        # lgbm does not support native multiple quantile regression
+        model = MultipleQuantileRegressor(
+            quantiles=quantiles, regressor=regressor, alpha_name="quantile"
+        )
+        super().__init__(
+            model=model,
+            lags=lags,
+            quantiles=quantiles,
+            include_seasonal_dummies=include_seasonal_dummies,
+            cyclical_encodings=cyclical_encodings,
+            X_lag_cols=X_lag_cols,
+        )

--- a/src/probafcst/models/linear_qr.py
+++ b/src/probafcst/models/linear_qr.py
@@ -15,15 +15,15 @@ class LinearQuantileForecaster(QuantileRegressionForecaster):
         include_seasonal_dummies=True,
         cyclical_encodings=True,
         X_lag_cols: list[str] | None = None,
-        est_kwargs: dict | None = None,
+        kwargs: dict | None = None,
     ):
-        self.est_kwargs = est_kwargs or {}
+        self.kwargs = kwargs or {}
 
         # use different default solver
-        if "solver" not in self.est_kwargs:
-            self.est_kwargs["solver"] = "highs-ipm"
+        if "solver" not in self.kwargs:
+            self.kwargs["solver"] = "highs-ipm"
 
-        regressor = QuantileRegressor(**self.est_kwargs)
+        regressor = QuantileRegressor(**self.kwargs)
         # lgbm does not support native multiple quantile regression
         model = MultipleQuantileRegressor(
             quantiles=quantiles, regressor=regressor, alpha_name="quantile"

--- a/src/probafcst/models/linear_qr.py
+++ b/src/probafcst/models/linear_qr.py
@@ -6,7 +6,10 @@ from .regression import MultipleQuantileRegressor, QuantileRegressionForecaster
 
 
 class LinearQuantileForecaster(QuantileRegressionForecaster):
-    """Linear Quantile Regression model."""
+    """Linear Quantile Regression model.
+
+    Fits separate quantile regressors for each quantile.
+    """
 
     def __init__(
         self,

--- a/src/probafcst/models/linear_qr.py
+++ b/src/probafcst/models/linear_qr.py
@@ -2,7 +2,7 @@
 
 from sklearn.linear_model import QuantileRegressor
 
-from ._regression import MultipleQuantileRegressor, QuantileRegressionForecaster
+from .regression import MultipleQuantileRegressor, QuantileRegressionForecaster
 
 
 class LinearQuantileForecaster(QuantileRegressionForecaster):

--- a/src/probafcst/models/regression.py
+++ b/src/probafcst/models/regression.py
@@ -136,6 +136,13 @@ class QuantileRegressionForecaster(BaseForecaster):
         If True, use cyclical (cos and sin functions) encoding for time features.
     X_lag_cols : list of str, default=None
         List of column names in X to include as lagged features. If None, all columns are used.
+
+    Attributes
+    ----------
+    max_lag_ : int
+        Maximum lag value used for creating lagged features.
+    freq_ : str
+        Inferred frequency of the time series index.
     """
 
     _tags = {

--- a/src/probafcst/models/xgboost.py
+++ b/src/probafcst/models/xgboost.py
@@ -4,7 +4,7 @@ import pandas as pd
 import xgboost as xgb
 from sktime.split import temporal_train_test_split
 
-from probafcst.models._regression import QuantileRegressionForecaster
+from probafcst.models.regression import QuantileRegressionForecaster
 from probafcst.utils.tabularization import create_lagged_features
 
 

--- a/src/probafcst/models/xgboost.py
+++ b/src/probafcst/models/xgboost.py
@@ -1,30 +1,15 @@
-"""Probabilistic XGBoost Forecasting Model."""
+"""Probabilistic XGBoost Regression Forecaster."""
 
-import numpy as np
 import pandas as pd
 import xgboost as xgb
-from loguru import logger
-from sktime.forecasting.base import BaseForecaster
 from sktime.split import temporal_train_test_split
 
+from probafcst.models._regression import QuantileRegressionForecaster
 from probafcst.utils.tabularization import create_lagged_features
 
 
-class XGBQuantileForecaster(BaseForecaster):
-    """XGBoost forecaster for probabilistic forecasting."""
-
-    _tags = {
-        "y_inner_mtype": "pd.Series",
-        "X_inner_mtype": "pd.DataFrame",
-        "scitype:y": "univariate",
-        "ignores-exogeneous-X": False,
-        "requires-fh-in-fit": False,
-        "enforce_index_type": pd.DatetimeIndex,
-        "X-y-must-have-same-index": True,
-        "handles-missing-data": False,
-        "capability:insample": False,
-        "capability:pred_int": True,
-    }
+class XGBQuantileForecaster(QuantileRegressionForecaster):
+    """Quantile regression forecaster using XGBoost."""
 
     def __init__(
         self,
@@ -35,20 +20,22 @@ class XGBQuantileForecaster(BaseForecaster):
         X_lag_cols: list[str] | None = None,
         xgb_kwargs: dict | None = None,
     ):
-        self.lags = lags
-        self.quantiles = quantiles
-        self.include_seasonal_dummies = include_seasonal_dummies
-        self.cyclical_encodings = cyclical_encodings
         self.xgb_kwargs = xgb_kwargs or {}
-        self.X_lag_cols = X_lag_cols
-
-        self.model = xgb.XGBRegressor(
+        model = xgb.XGBRegressor(
             objective="reg:quantileerror",
             quantile_alpha=quantiles,
-            **self.xgb_kwargs,
+            **(xgb_kwargs or {}),
         )
-        super().__init__()
+        super().__init__(
+            model=model,
+            lags=lags,
+            quantiles=quantiles,
+            include_seasonal_dummies=include_seasonal_dummies,
+            cyclical_encodings=cyclical_encodings,
+            X_lag_cols=X_lag_cols,
+        )
 
+    # override _fit method to add early stopping capability
     def _fit(self, y, X, fh=None):
         self.freq_ = pd.infer_freq(y.index)
         self._target_name = self._y_metadata["feature_names"][0]
@@ -82,76 +69,5 @@ class XGBQuantileForecaster(BaseForecaster):
             )
         else:
             self.model.fit(features, labels)
-
         self.feature_names_in_ = features.columns
         return self
-
-    def _predict(self, fh, X=None):
-        # Use _predict_quantiles() to get the median for point prediction
-        quantile_predictions = self._predict_quantiles(fh, X=X, alpha=self.quantiles)
-        return quantile_predictions[(self._target_name, 0.5)]
-
-    def _predict_quantiles(self, fh, X, alpha):
-        if X is None:
-            # index must be the one in _y plus the forecast horizon
-            index = self._y.index.union(fh.to_absolute_index(self.cutoff))
-            X = pd.DataFrame(index=index)
-
-        if X.shape[0] < len(fh):
-            raise ValueError(f"X must contain at least {self.max_lag_} rows")
-        elif X.shape[0] > len(fh):
-            max_needed_timestamp = fh.to_absolute_index(self.cutoff).max()
-            X = X.loc[:max_needed_timestamp]
-            logger.debug(f"X truncated to {X.index[0]} - {X.index[-1]}")
-
-        logger.debug(f"Predicting {len(fh)} steps ahead.")
-        logger.debug(f"Future X shape: {X.shape}")
-
-        assert alpha == self.quantiles, "alpha must be equal to quantiles used in fit"
-
-        y_train = self._y.copy()
-
-        X_full = X.copy()
-        logger.debug(f"X values available from {X_full.index[0]} to {X_full.index[-1]}")
-
-        forecast_index = fh.to_absolute_index(self.cutoff)
-        y_pred = pd.Series(np.nan, index=forecast_index)
-        y_full = pd.concat([y_train, y_pred])
-        y_full.name = self._target_name
-
-        logger.debug(f"Forecast index: {forecast_index[0]} - {forecast_index[-1]}")
-
-        # Initialize results DataFrame
-        results = pd.DataFrame(index=forecast_index, columns=[q for q in alpha])
-
-        for timestamp in forecast_index:
-            X_lagged, _ = create_lagged_features(
-                X=X_full,
-                y=y_full,
-                lags=self.lags,
-                include_seasonal_dummies=self.include_seasonal_dummies,
-                cyclical_encodings=self.cyclical_encodings,
-                X_lag_cols=self.X_lag_cols,
-                is_training=False,
-                freq=self.freq_,
-            )
-
-            X_step = X_lagged.loc[[timestamp]]
-            pred_quantiles_step = self.model.predict(X_step)
-            results.loc[timestamp] = pred_quantiles_step
-
-            # append the median prediction to use for lag creation in the next step
-            median_pred = results.loc[timestamp, 0.5]
-            y_full.loc[timestamp] = median_pred
-
-        columns = pd.MultiIndex.from_product(
-            [[self._target_name], alpha], names=["variable", "quantiles"]
-        )
-        results.columns = columns
-        results = results.astype(float)
-
-        # sort each row in dataframe y_pred ascending over the columns
-        predictions = results.to_numpy()
-        predictions.sort(axis=1)
-        results.iloc[:, :] = predictions
-        return results

--- a/src/probafcst/models/xgboost.py
+++ b/src/probafcst/models/xgboost.py
@@ -18,13 +18,13 @@ class XGBQuantileForecaster(QuantileRegressionForecaster):
         include_seasonal_dummies=True,
         cyclical_encodings=True,
         X_lag_cols: list[str] | None = None,
-        xgb_kwargs: dict | None = None,
+        kwargs: dict | None = None,
     ):
-        self.xgb_kwargs = xgb_kwargs or {}
+        self.kwargs = kwargs or {}
         model = xgb.XGBRegressor(
             objective="reg:quantileerror",
             quantile_alpha=quantiles,
-            **(xgb_kwargs or {}),
+            **self.kwargs,
         )
         super().__init__(
             model=model,
@@ -55,7 +55,7 @@ class XGBQuantileForecaster(QuantileRegressionForecaster):
             freq=self.freq_,
         )
 
-        if "early_stopping_rounds" in self.xgb_kwargs:
+        if "early_stopping_rounds" in self.kwargs:
             train_features, val_features, train_labels, val_labels = (
                 temporal_train_test_split(
                     features, labels, test_size=30 if self.freq_ == "D" else 24 * 7

--- a/tests/models/test__regression.py
+++ b/tests/models/test__regression.py
@@ -1,0 +1,29 @@
+"""Test the _regression module."""
+
+import numpy as np
+import pandas as pd
+from sklearn.linear_model import QuantileRegressor
+
+from probafcst.models._regression import MultipleQuantileRegressor
+
+
+def test_MultipleQuantileRegressor():
+    """Test the MultipleQuantileRegressor class."""
+    regressor = QuantileRegressor()
+    model = MultipleQuantileRegressor(
+        quantiles=[0.1, 0.9], regressor=regressor, alpha_name="quantile", n_jobs=2
+    )
+
+    # Test fit
+    X = pd.DataFrame({"feature": [1, 2, 3]})
+    y = pd.Series([1, 2, 3])
+    model.fit(X, y)
+    assert len(model.regressors_) == 2
+    for q, regressor in model.regressors_.items():
+        assert regressor.quantile == q
+
+    # Test predict
+    X = pd.DataFrame({"feature": [4, 5, 6]})
+    predictions = model.predict(X)
+    assert predictions.shape == (3, 2)
+    assert np.all(predictions[:, 0] <= predictions[:, 1])

--- a/tests/models/test__regression.py
+++ b/tests/models/test__regression.py
@@ -4,7 +4,7 @@ import numpy as np
 import pandas as pd
 from sklearn.linear_model import QuantileRegressor
 
-from probafcst.models._regression import MultipleQuantileRegressor
+from probafcst.models.regression import MultipleQuantileRegressor
 
 
 def test_MultipleQuantileRegressor():

--- a/tests/models/test_xgboost.py
+++ b/tests/models/test_xgboost.py
@@ -39,7 +39,7 @@ def test_xgboost_evaluate_no_X(energy_sample, include_seasonal_dummies):
         quantiles=QUANTILES,
         include_seasonal_dummies=include_seasonal_dummies,
         cyclical_encodings=False,
-        xgb_kwargs={"n_jobs": 1, "n_estimators": 10},
+        kwargs={"n_jobs": 1, "n_estimators": 10},
     )
     # generate three splits, using 6 weeks for training
     backtest_results = backtest(
@@ -67,7 +67,7 @@ def test_xgboost_evaluate_with_X(energy_sample):
         quantiles=QUANTILES,
         include_seasonal_dummies=False,
         cyclical_encodings=False,
-        xgb_kwargs={"n_jobs": 1, "n_estimators": 10},
+        kwargs={"n_jobs": 1, "n_estimators": 10},
     )
     # generate three splits, using 6 weeks for training
     backtest_results = backtest(

--- a/uv.lock
+++ b/uv.lock
@@ -2042,6 +2042,23 @@ wheels = [
 ]
 
 [[package]]
+name = "lightgbm"
+version = "4.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "scipy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/e6/41be1f8642257e21b4170e798c9a84e4268656ebfa3019586d82bfd281c9/lightgbm-4.5.0.tar.gz", hash = "sha256:e1cd7baf0318d4e308a26575a63a4635f08df866ad3622a9d8e3d71d9637a1ba", size = 1701072 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/d2/46520b6e255298e920df26ff6e5e4fc788c927886e1e30a96b27c2f94924/lightgbm-4.5.0-py3-none-macosx_10_15_x86_64.whl", hash = "sha256:2212e2166af6379bc005e6f7041dd2dcba3750238eccbc55d09d3c0717c51187", size = 1923168 },
+    { url = "https://files.pythonhosted.org/packages/11/3f/49913ed111286e23bcc40daab54542d80924264dca8ae371514039ab83ab/lightgbm-4.5.0-py3-none-macosx_12_0_arm64.whl", hash = "sha256:1301aa853e1fe4bf318539aa132f373862b04aa537af502508711ce03dffff09", size = 1575672 },
+    { url = "https://files.pythonhosted.org/packages/84/6a/10c4921526600559530d49d70553d1bc1bd84c616808c629a620a6160305/lightgbm-4.5.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7f0a3dded769d83560845f2c3fe1966630ec1ca527c380d9d48d9b35579a796e", size = 3425739 },
+    { url = "https://files.pythonhosted.org/packages/4e/19/1b928cad70a4e1a3e2c37d5417ca2182510f2451eaadb6c91cd9ec692cae/lightgbm-4.5.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:960a0e7c077de0ca3053f1325d3edfc92ea815acf5176adcacdea0f635aeef9b", size = 3552481 },
+    { url = "https://files.pythonhosted.org/packages/d9/28/3be76b591a2e14a031b681b8283acf1dec2ad521f6f1701b7957df68c466/lightgbm-4.5.0-py3-none-win_amd64.whl", hash = "sha256:7ccb73ee9fb74fbbf89ad24c57a6edad505aa8f2165d02b999a082dbbbb0ee57", size = 1444319 },
+]
+
+[[package]]
 name = "lightning-utilities"
 version = "0.11.8"
 source = { registry = "https://pypi.org/simple" }
@@ -3016,6 +3033,7 @@ dependencies = [
     { name = "dvc" },
     { name = "dvc-s3" },
     { name = "holidays" },
+    { name = "lightgbm" },
     { name = "loguru" },
     { name = "matplotlib" },
     { name = "numpy" },
@@ -3051,6 +3069,7 @@ requires-dist = [
     { name = "dvc", specifier = ">=3.55.2" },
     { name = "dvc-s3", specifier = ">=3.2.0" },
     { name = "holidays", specifier = ">=0.59" },
+    { name = "lightgbm", specifier = ">=4.5.0" },
     { name = "loguru", specifier = ">=0.7.2" },
     { name = "matplotlib", specifier = ">=3.9.2" },
     { name = "numpy", specifier = "<2.0.0" },
@@ -3913,6 +3932,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/b7/20c6f3c0b656fe609675d69bc135c03aac9e3865912444be6339207b6648/ruamel.yaml.clib-0.2.12-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f66efbc1caa63c088dead1c4170d148eabc9b80d95fb75b6c92ac0aad2437d76", size = 686712 },
     { url = "https://files.pythonhosted.org/packages/cd/11/d12dbf683471f888d354dac59593873c2b45feb193c5e3e0f2ebf85e68b9/ruamel.yaml.clib-0.2.12-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:22353049ba4181685023b25b5b51a574bce33e7f51c759371a7422dcae5402a6", size = 663936 },
     { url = "https://files.pythonhosted.org/packages/72/14/4c268f5077db5c83f743ee1daeb236269fa8577133a5cfa49f8b382baf13/ruamel.yaml.clib-0.2.12-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:932205970b9f9991b34f55136be327501903f7c66830e9760a8ffb15b07f05cd", size = 696580 },
+    { url = "https://files.pythonhosted.org/packages/30/fc/8cd12f189c6405a4c1cf37bd633aa740a9538c8e40497c231072d0fef5cf/ruamel.yaml.clib-0.2.12-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:a52d48f4e7bf9005e8f0a89209bf9a73f7190ddf0489eee5eb51377385f59f2a", size = 663393 },
     { url = "https://files.pythonhosted.org/packages/80/29/c0a017b704aaf3cbf704989785cd9c5d5b8ccec2dae6ac0c53833c84e677/ruamel.yaml.clib-0.2.12-cp310-cp310-win32.whl", hash = "sha256:3eac5a91891ceb88138c113f9db04f3cebdae277f5d44eaa3651a4f573e6a5da", size = 100326 },
     { url = "https://files.pythonhosted.org/packages/3a/65/fa39d74db4e2d0cd252355732d966a460a41cd01c6353b820a0952432839/ruamel.yaml.clib-0.2.12-cp310-cp310-win_amd64.whl", hash = "sha256:ab007f2f5a87bd08ab1499bdf96f3d5c6ad4dcfa364884cb4549aa0154b13a28", size = 118079 },
     { url = "https://files.pythonhosted.org/packages/fb/8f/683c6ad562f558cbc4f7c029abcd9599148c51c54b5ef0f24f2638da9fbb/ruamel.yaml.clib-0.2.12-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:4a6679521a58256a90b0d89e03992c15144c5f3858f40d7c18886023d7943db6", size = 132224 },
@@ -3921,6 +3941,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/86/29/88c2567bc893c84d88b4c48027367c3562ae69121d568e8a3f3a8d363f4d/ruamel.yaml.clib-0.2.12-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:811ea1594b8a0fb466172c384267a4e5e367298af6b228931f273b111f17ef52", size = 703012 },
     { url = "https://files.pythonhosted.org/packages/11/46/879763c619b5470820f0cd6ca97d134771e502776bc2b844d2adb6e37753/ruamel.yaml.clib-0.2.12-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:cf12567a7b565cbf65d438dec6cfbe2917d3c1bdddfce84a9930b7d35ea59642", size = 704352 },
     { url = "https://files.pythonhosted.org/packages/02/80/ece7e6034256a4186bbe50dee28cd032d816974941a6abf6a9d65e4228a7/ruamel.yaml.clib-0.2.12-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:7dd5adc8b930b12c8fc5b99e2d535a09889941aa0d0bd06f4749e9a9397c71d2", size = 737344 },
+    { url = "https://files.pythonhosted.org/packages/f0/ca/e4106ac7e80efbabdf4bf91d3d32fc424e41418458251712f5672eada9ce/ruamel.yaml.clib-0.2.12-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1492a6051dab8d912fc2adeef0e8c72216b24d57bd896ea607cb90bb0c4981d3", size = 714498 },
     { url = "https://files.pythonhosted.org/packages/67/58/b1f60a1d591b771298ffa0428237afb092c7f29ae23bad93420b1eb10703/ruamel.yaml.clib-0.2.12-cp311-cp311-win32.whl", hash = "sha256:bd0a08f0bab19093c54e18a14a10b4322e1eacc5217056f3c063bd2f59853ce4", size = 100205 },
     { url = "https://files.pythonhosted.org/packages/b4/4f/b52f634c9548a9291a70dfce26ca7ebce388235c93588a1068028ea23fcc/ruamel.yaml.clib-0.2.12-cp311-cp311-win_amd64.whl", hash = "sha256:a274fb2cb086c7a3dea4322ec27f4cb5cc4b6298adb583ab0e211a4682f241eb", size = 118185 },
     { url = "https://files.pythonhosted.org/packages/48/41/e7a405afbdc26af961678474a55373e1b323605a4f5e2ddd4a80ea80f628/ruamel.yaml.clib-0.2.12-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:20b0f8dc160ba83b6dcc0e256846e1a02d044e13f7ea74a3d1d56ede4e48c632", size = 133433 },
@@ -3929,6 +3950,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/52/a9/d39f3c5ada0a3bb2870d7db41901125dbe2434fa4f12ca8c5b83a42d7c53/ruamel.yaml.clib-0.2.12-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:749c16fcc4a2b09f28843cda5a193e0283e47454b63ec4b81eaa2242f50e4ccd", size = 706497 },
     { url = "https://files.pythonhosted.org/packages/b0/fa/097e38135dadd9ac25aecf2a54be17ddf6e4c23e43d538492a90ab3d71c6/ruamel.yaml.clib-0.2.12-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:bf165fef1f223beae7333275156ab2022cffe255dcc51c27f066b4370da81e31", size = 698042 },
     { url = "https://files.pythonhosted.org/packages/ec/d5/a659ca6f503b9379b930f13bc6b130c9f176469b73b9834296822a83a132/ruamel.yaml.clib-0.2.12-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:32621c177bbf782ca5a18ba4d7af0f1082a3f6e517ac2a18b3974d4edf349680", size = 745831 },
+    { url = "https://files.pythonhosted.org/packages/db/5d/36619b61ffa2429eeaefaab4f3374666adf36ad8ac6330d855848d7d36fd/ruamel.yaml.clib-0.2.12-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b82a7c94a498853aa0b272fd5bc67f29008da798d4f93a2f9f289feb8426a58d", size = 715692 },
     { url = "https://files.pythonhosted.org/packages/b1/82/85cb92f15a4231c89b95dfe08b09eb6adca929ef7df7e17ab59902b6f589/ruamel.yaml.clib-0.2.12-cp312-cp312-win32.whl", hash = "sha256:e8c4ebfcfd57177b572e2040777b8abc537cdef58a2120e830124946aa9b42c5", size = 98777 },
     { url = "https://files.pythonhosted.org/packages/d7/8f/c3654f6f1ddb75daf3922c3d8fc6005b1ab56671ad56ffb874d908bfa668/ruamel.yaml.clib-0.2.12-cp312-cp312-win_amd64.whl", hash = "sha256:0467c5965282c62203273b838ae77c0d29d7638c8a4e3a1c8bdd3602c10904e4", size = 115523 },
     { url = "https://files.pythonhosted.org/packages/29/00/4864119668d71a5fa45678f380b5923ff410701565821925c69780356ffa/ruamel.yaml.clib-0.2.12-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:4c8c5d82f50bb53986a5e02d1b3092b03622c02c2eb78e29bec33fd9593bae1a", size = 132011 },
@@ -3937,6 +3959,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e2/a9/28f60726d29dfc01b8decdb385de4ced2ced9faeb37a847bd5cf26836815/ruamel.yaml.clib-0.2.12-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:96777d473c05ee3e5e3c3e999f5d23c6f4ec5b0c38c098b3a5229085f74236c6", size = 701785 },
     { url = "https://files.pythonhosted.org/packages/84/7e/8e7ec45920daa7f76046578e4f677a3215fe8f18ee30a9cb7627a19d9b4c/ruamel.yaml.clib-0.2.12-cp313-cp313-musllinux_1_1_i686.whl", hash = "sha256:3bc2a80e6420ca8b7d3590791e2dfc709c88ab9152c00eeb511c9875ce5778bf", size = 693017 },
     { url = "https://files.pythonhosted.org/packages/c5/b3/d650eaade4ca225f02a648321e1ab835b9d361c60d51150bac49063b83fa/ruamel.yaml.clib-0.2.12-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:e188d2699864c11c36cdfdada94d781fd5d6b0071cd9c427bceb08ad3d7c70e1", size = 741270 },
+    { url = "https://files.pythonhosted.org/packages/87/b8/01c29b924dcbbed75cc45b30c30d565d763b9c4d540545a0eeecffb8f09c/ruamel.yaml.clib-0.2.12-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4f6f3eac23941b32afccc23081e1f50612bdbe4e982012ef4f5797986828cd01", size = 709059 },
     { url = "https://files.pythonhosted.org/packages/30/8c/ed73f047a73638257aa9377ad356bea4d96125b305c34a28766f4445cc0f/ruamel.yaml.clib-0.2.12-cp313-cp313-win32.whl", hash = "sha256:6442cb36270b3afb1b4951f060eccca1ce49f3d087ca1ca4563a6eb479cb3de6", size = 98583 },
     { url = "https://files.pythonhosted.org/packages/b0/85/e8e751d8791564dd333d5d9a4eab0a7a115f7e349595417fd50ecae3395c/ruamel.yaml.clib-0.2.12-cp313-cp313-win_amd64.whl", hash = "sha256:e5b8daf27af0b90da7bb903a876477a9e6d7270be6146906b276605997c7e9a3", size = 115190 },
 ]


### PR DESCRIPTION
Refactors XGBQuantileForecaster into a parent and child class, namely QuantileRegressionForecaster.
Also adds LightGBM model as quantile regression, using the new MultipleQuantileRegressor class to fit one lgbm model per quantile level. This also closes #15 as implementation was very easy once lgbm was implemented.